### PR TITLE
⚡ Isolate `useTime` hook in `Clock` component to prevent redundant re-renders

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -1,10 +1,7 @@
 import React from "react";
 import styles from '@/styles/Home.module.css'
 import dayjs from "dayjs";
-
-interface Props {
-    time: number
-};
+import { useTime } from "@/useTime";
 
 function toDateStr(date: string): string {
     if (date.endsWith("1")) {
@@ -44,7 +41,8 @@ function getDateStr(month: number, date: string): string {
     return toDateStr(date)+"/"+toMonthStr(month);
 }
 
-export const Clock: React.FC<Props> = ({time}) => {
+export const Clock: React.FC = () => {
+    const time = useTime(1000);
     const timeStr = dayjs(time).format("HH:mm:ss");
     const month = dayjs(time).month();
     const date = dayjs(time).format("DD");

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,14 +3,11 @@ import styles from '../styles/Home.module.css'
 import { useState, useEffect } from "react";
 // import { LinkButton } from "@/components/LinkButton";
 import { Clock } from "@/components/Clock";
-import { useTime } from "@/useTime";
 import { getUrl } from "@/utils/config";
 import type { Task } from "@/lib/linear";
 import { fetchUserId, fetchTasks } from "@/lib/linear";
 
 export default function Home() {
-  const time = useTime(1000);
-
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const searchGoogle = (event: any) => {
@@ -51,7 +48,7 @@ export default function Home() {
         }}
         className={styles.main}
       >
-        <Clock time={time} />
+        <Clock />
         <form className={styles.searchForm} onSubmit={searchGoogle}>
           <input
             onChange={(event) => setQuery(event.target.value)}


### PR DESCRIPTION
💡 **What:** Moved the `useTime` hook from the `Home` component directly into the `Clock` component. This also involved removing the `time` prop from `Clock` and cleaning up its now-empty `Props` interface.

🎯 **Why:** Previously, the `useTime` hook triggered a state update every second in the top-level `Home` component. This caused the entire page—including the search form and the potentially large list of Linear tasks—to re-render on every tick. By isolating this timer state within the `Clock` component, we ensure that only the clock itself re-renders every second.

📊 **Measured Improvement:** In this environment, `npm install` and `next build` were unable to complete due to network timeouts and missing binaries. However, based on React's fundamental rendering behavior, this change significantly reduces the work performed by the browser's main thread by eliminating redundant virtual DOM diffing for the heavy `Home` component 60 times per minute.

---
*PR created automatically by Jules for task [11320293100876120326](https://jules.google.com/task/11320293100876120326) started by @tokitaku*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the Clock component to manage its own internal timing, simplifying the component hierarchy and reducing prop dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->